### PR TITLE
Fix capitalization of "Typescript" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <div align="center">
 <img src="./icon.png" width="20%" />
 <h3> diep custom </h3>
-<p> A recreation of diep's physics, protocol, and backend in Typescript </p>
+<p> A recreation of diep's physics, protocol, and backend in TypeScript </p>
 </div>
 <br>
 


### PR DESCRIPTION
TypeScript should always be treated as a PascalCase name. Every instance of the word "TypeScript" on the official website is capitalized this way: https://www.typescriptlang.org/