### PR TITLE
fix(#13): entities velocity gets halfed when dying

### DIFF
--- a/src/Entity/Object.ts
+++ b/src/Entity/Object.ts
@@ -178,7 +178,8 @@ export default class ObjectEntity extends Entity {
         this.velocity.add(this.accel);
 
         if (this.velocity.magnitude < 0.01) this.velocity.magnitude = 0;
-
+        // when being deleted, entities slow down half speed
+        else if (this.deletionAnimation) this.velocity.magnitude /= 2;
         this.position.x += this.velocity.x;
         this.position.y += this.velocity.y;
 

--- a/src/Entity/Tank/Projectile/Bullet.ts
+++ b/src/Entity/Tank/Projectile/Bullet.ts
@@ -112,7 +112,6 @@ export default class Bullet extends LivingEntity {
         super.tick(tick);
 
         if (tick === this.spawnTick + 1) this.addAcceleration(this.movementAngle, this.baseSpeed);
-        else if (this.deletionAnimation) this.maintainVelocity(this.usePosAngle ? this.position.values.angle : this.movementAngle, this.baseAccel / 2);
         else this.maintainVelocity(this.usePosAngle ? this.position.values.angle : this.movementAngle, this.baseAccel);
 
         if (tick - this.spawnTick >= this.lifeLength) this.destroy(true);


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes #13 

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
When dying, an entity's velocity is now halfed before getting applied to position
### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

