### PR TITLE
fix(#23): add cheatflag when dev cheats used, make it persist

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -103,8 +103,8 @@ export default class Client {
     /** The client's IP Address */
     public ipAddress: string;
 
-    /** Whether or not the player is cheating. */
-    private cheater = 0;
+    /** Whether or not the player has used in game dev cheats before (such as level up or godmode). */
+    private devCheatsUsed = 0;
 
     /** Returns a new writer stream connected to the socket. */
     public write() {
@@ -278,9 +278,9 @@ export default class Client {
 
                 if ((flags & InputFlags.godmode) && (this.accessLevel >= config.AccessLevel.BetaAccess || true)) {
                     player.name.nametag |= NametagFlags.cheats;
-                    this.cheater = 1;
+                    this.devCheatsUsed = 1;
 
-                    player.setTank(player.currentTank < 0 ? DevTank.Developer : Tank.Basic);
+                    player.setTank(player.currentTank < 0 ? Tank.Basic : DevTank.Developer);
                 }
 
                 if ((flags & InputFlags.rightclick) && !(previousFlags & InputFlags.rightclick) && player.currentTank === DevTank.Developer) {
@@ -291,7 +291,7 @@ export default class Client {
                 }
                 if ((flags & InputFlags.switchtank) && !(previousFlags & InputFlags.switchtank)) {
                     player.name.nametag |= NametagFlags.cheats;
-                    this.cheater = 1;
+                    this.devCheatsUsed = 1;
                     
                     let tank = player.currentTank;
                     if (tank >= 0) {
@@ -316,14 +316,14 @@ export default class Client {
                 if (flags & InputFlags.levelup) {
                     if ((this.accessLevel === config.AccessLevel.FullAccess) || camera.camera.values.level < 45) {
                         player.name.nametag |= NametagFlags.cheats;
-                        this.cheater = 1;
+                        this.devCheatsUsed = 1;
                         
                         camera.setLevel(camera.camera.values.level + 1);
                     }
                 }
                 if ((flags & InputFlags.suicide) && (!player.deletionAnimation || !player.deletionAnimation)) {
                     player.name.nametag |= NametagFlags.cheats;
-                    this.cheater = 1;
+                    this.devCheatsUsed = 1;
                     
                     this.notify("You've killed " + (player.name.values.name === "" ? "an unnamed tank" : player.name.values.name));
                     camera.camera.killedBy = player.name.values.name;
@@ -351,7 +351,7 @@ export default class Client {
                 camera.setLevel(camera.camera.values.respawnLevel);
 
                 tank.name.values.name = name;
-                if (this.cheater) tank.name.values.nametag |= NametagFlags.cheats;
+                if (this.devCheatsUsed) tank.name.values.nametag |= NametagFlags.cheats;
 
                 // Force-send a creation to the client - Only if it is not new
                 camera.state = EntityStateFlags.needsCreate | EntityStateFlags.needsDelete;

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -310,7 +310,7 @@ export default class Client {
                         while (!DevTankDefinitions[tank] || DevTankDefinitions[tank].flags.devOnly === true && !isDeveloper) {
                             tank = (tank + 1) % DevTankDefinitions.length;
                         }
-                        tank = ~tank
+                        tank = ~tank;
                     }
 
                     player.setTank(tank);
@@ -359,8 +359,7 @@ export default class Client {
                 camera.spectatee = null;
                 this.inputs.isPossessing = false;
 
-                /** @ts-ignore: Entity.exists() is checked beforehand. */
-                if (this.cheater) camera.camera.values.player.name.nametag |= NametagFlags.cheats;
+                if (this.cheater) tank.name.values.nametag |= NametagFlags.cheats;
                 return;
             }
             case ServerBound.StatUpgrade: {

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -104,7 +104,7 @@ export default class Client {
     public ipAddress: string;
 
     /** Whether or not the player is cheating. */
-    public cheater = 0;
+    private cheater = 0;
 
     /** Returns a new writer stream connected to the socket. */
     public write() {
@@ -277,14 +277,12 @@ export default class Client {
                 if (this.inputs.isPossessing && this.accessLevel !== config.AccessLevel.FullAccess) return;
 
                 if ((flags & InputFlags.godmode) && (this.accessLevel >= config.AccessLevel.BetaAccess || true)) {
-                    if (player.currentTank < 0) player.setTank(Tank.Basic);
-                    else { 
-                        player.name.nametag |= NametagFlags.cheats;
-                        this.cheater = 1;
+                    player.name.nametag |= NametagFlags.cheats;
+                    this.cheater = 1;
 
-                        player.setTank(DevTank.Developer);
-                    }
+                    player.setTank(player.currentTank < 0 ? DevTank.Developer : Tank.Basic);
                 }
+
                 if ((flags & InputFlags.rightclick) && !(previousFlags & InputFlags.rightclick) && player.currentTank === DevTank.Developer) {
                     player.position.x = this.inputs.mouse.x;
                     player.position.y = this.inputs.mouse.y;
@@ -353,13 +351,12 @@ export default class Client {
                 camera.setLevel(camera.camera.values.respawnLevel);
 
                 tank.name.values.name = name;
+                if (this.cheater) tank.name.values.nametag |= NametagFlags.cheats;
 
                 // Force-send a creation to the client - Only if it is not new
                 camera.state = EntityStateFlags.needsCreate | EntityStateFlags.needsDelete;
                 camera.spectatee = null;
                 this.inputs.isPossessing = false;
-
-                if (this.cheater) tank.name.values.nametag |= NametagFlags.cheats;
                 return;
             }
             case ServerBound.StatUpgrade: {


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes https://github.com/ABCxFF/diepcustom/issues/23

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
Switching tanks, suiciding and pressing godmode now append `NametagFlags.cheats` to it. Unless you disconnect, the cheat flag will persist, as in Diep.io.
### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

