### PR TITLE
fix: team base damage indicator

### DIFF
--- a/src/Entity/Live.ts
+++ b/src/Entity/Live.ts
@@ -62,6 +62,7 @@ export default class LivingEntity extends ObjectEntity {
         if (entity1.health.values.health <= 0 || entity2.health.values.health <= 0) return;
         if (entity1.damagedEntities.includes(entity2) || entity2.damagedEntities.includes(entity1)) return;
         if ((entity1.style.values.styleFlags & StyleFlags.invincibility) && (entity2.style.values.styleFlags & StyleFlags.invincibility)) return;
+        if (entity1.damagePerTick == 0 || entity2.damagePerTick == 0) return;
 
         const game = entity1.game;
 

--- a/src/Entity/Misc/TeamBase.ts
+++ b/src/Entity/Misc/TeamBase.ts
@@ -53,7 +53,7 @@ export default class TeamBase extends LivingEntity {
         this.style.values.opacity = 0.1;
         this.style.values.borderThickness = 0;
         this.style.values.color = team.team.teamColor;
-        this.style.values.styleFlags |= StyleFlags.minimap2;
+        this.style.values.styleFlags |= StyleFlags.minimap2 | StyleFlags.noDmgIndicator;
 
         this.health.healthbar |= HealthbarFlags.hidden
         this.health.health = this.health.values.maxHealth = 0xABCFF;


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes [issue link]

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
team bases having damage flash
### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

