### PR TITLE
Implementing custom tank definition loading

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -237,7 +237,7 @@ const WASM_EXPORTS = {
 const MOD_CONFIG = {
     "wasmFunctions": {
         "loadGamemodeButtons": 296,
-        "vectorCtorDone": 22,
+        "loadVectorDone": 22,
         "loadChangelog": 447,
         "loadTankDefinitions": 277,
         "getTankDefinition": 101

--- a/client/config.js
+++ b/client/config.js
@@ -20,7 +20,7 @@ const BUILD = "6f59094d60f98fafc14371671d3ff31ef4d75d9e";
 const CDN = "https://static.diep.io/";
 
 const CHANGELOG = [
-    "Updated not so long time ago",
+    "Updated recently",
     "",
     "Check out the github repo: github.com/ABCxFF/diepcustom",
     "Join out discord: https://discord.com/invite/SyxWdxgHnT :)"
@@ -235,14 +235,18 @@ const WASM_EXPORTS = {
 
 const MOD_CONFIG = {
     "wasmFunctions": {
-        "tankDefsCtor": 276,
         "loadGamemodeButtons": 296,
         "vectorCtorDone": 22,
-        "loadChangelog": 447
+        "loadChangelog": 447,
+        "loadTankDefinitions": 277,
+        "getTankDefinition": 101
     },
     "memory": {
         "gamemodeButtons": 113480,
-        "changelog": 167328
+        "changelog": 167328,
+        "changelogLoaded": 168632,
+        "tankDefinitions": 166572,
+        "tankDefinitionsCount": 166576
     },
     "wasmFunctionHookOffset": {
         "gamemodeButtons": 33,

--- a/client/config.js
+++ b/client/config.js
@@ -18,6 +18,7 @@
 
 const BUILD = "6f59094d60f98fafc14371671d3ff31ef4d75d9e";
 const CDN = "https://static.diep.io/";
+const API_URL = "http://localhost:8080/api/";
 
 const CHANGELOG = [
     "Updated recently",

--- a/client/config.js
+++ b/client/config.js
@@ -254,6 +254,25 @@ const MOD_CONFIG = {
     }
 };
 
+const ADDON_MAP = {
+    "barrelAddons": {
+        "trapLauncher": 147
+    },
+    "tankAddons": {
+        "auto3": 148,
+        "smasher": 149,
+        "pronounced": 150,
+        "landmine": 151,
+        "auto5": 153,
+        "autoturret": 154, // Auto Trapper (154) & Auto Gunner (152)
+        "autosmasher": 155,
+        "spike": 156,
+        "launcher": 157, // Skimmer (157) & Rocketeer (158)
+        "dombase": 159,
+        "dompronounced": 160, // Dom1 (160) & Dom2 (161) 
+    }
+};
+
 const WASM_TABLE = {
     "initial": 687,
     "maximum": 687,

--- a/client/dma.js
+++ b/client/dma.js
@@ -20,7 +20,7 @@ const setupDMAHelpers = () => {
     $.write = (ptr, type, value) => {
         switch(type) {
             case "struct": return $.writeStruct(ptr, value);
-            case "vector": return new $.Vector(ptr, value.type, value.typeSize).push(value.entries);
+            case "vector": return new $.Vector(ptr, value.type, value.typeSize).push(...value.entries);
             default: return $(ptr)[type] = value;
         }
     }
@@ -82,6 +82,7 @@ const setupDMAHelpers = () => {
         }
     
         _malloc() {
+            this.maxEntries = (this.maxCapacity - this.start) / this.typeSize;
             this.totalSize = this.entries.length * this.typeSize;
             this.start = Module.exports.malloc(this.totalSize);
             this.end = this.start;

--- a/client/loader.js
+++ b/client/loader.js
@@ -123,6 +123,7 @@ Module.getTankDefinition = tankId => {
 
 Module.loadTankDefinitions = () => {
     const writeTankDef = (ptr, tank) => {
+        // Please note that this is not the full tank/barrel struct but just the portion needed for the client to function properly
         const barrels = tank.barrels ? tank.barrels.map(barrel => {
             return [
                 { offset: 0, type: "f32", value: barrel.angle },

--- a/client/loader.js
+++ b/client/loader.js
@@ -203,7 +203,7 @@ Module.todo.push([() => {
 
 Module.todo.push([() => {
     Module.status = "FETCH";
-    return [fetch(`${CDN}build_${BUILD}.wasm.wasm`).then(res => res.arrayBuffer()), fetch(`${API_URL}servers`).then(res => res.json()), fetch(${API_URL}tanks).then(res => res.json())];
+    return [fetch(`${CDN}build_${BUILD}.wasm.wasm`).then(res => res.arrayBuffer()), fetch(`${API_URL}servers`).then(res => res.json()), fetch(`${API_URL}tanks`).then(res => res.json())];
 }, true]);
 
 Module.todo.push([(dependency, servers, tanks) => {

--- a/client/loader.js
+++ b/client/loader.js
@@ -269,12 +269,14 @@ Module.todo.push([(dependency, servers, tanks) => {
                 return new Uint8Array([
                     ...bytes.subarray(0, MOD_CONFIG.wasmFunctionHookOffset.changelog),
                     OP_CALL, ...VarUint32ToArray(loadChangelog.i32()),
+                    OP_RETURN,
                     ...bytes.subarray(MOD_CONFIG.wasmFunctionHookOffset.changelog)
                   ]);
             case originalLoadGamemodeButtons.i32(): // we only need the part where it checks if the buttons are already loaded to avoid too many import calls
                 return new Uint8Array([
                     ...bytes.subarray(0, MOD_CONFIG.wasmFunctionHookOffset.gamemodeButtons),
                     OP_CALL, ...VarUint32ToArray(loadGamemodeButtons.i32()),
+                    OP_RETURN,
                     ...bytes.subarray(MOD_CONFIG.wasmFunctionHookOffset.gamemodeButtons)
                 ]);
             case originalGetTankDef.i32(): // we modify this to call a js function which then returns the tank def ptr from a table

--- a/client/loader.js
+++ b/client/loader.js
@@ -109,7 +109,7 @@ Module.loadChangelog = () => {
     const vec = new $.Vector(MOD_CONFIG.memory.changelog, 'cstr', 12);
     if(vec.start) vec.delete();
     vec.push(...CHANGELOG);
-    $(168632).i8 = 1;
+    $(MOD_CONFIG.memory.changelogLoaded).i8 = 1;
 };
 
 const wasmImports = {

--- a/client/loader.js
+++ b/client/loader.js
@@ -135,7 +135,7 @@ Module.loadTankDefinitions = () => {
                 { offset: 56, type: "f32", value: barrel.bullet.sizeRatio },
                 { offset: 60, type: "f32", value: barrel.trapezoidDirection },
                 { offset: 64, type: "f32", value: barrel.reload },
-                { offset: 96, type: "u32", value: ADDONMAP.barrelAddons[barrel.addon] || 0 }
+                { offset: 96, type: "u32", value: ADDON_MAP.barrelAddons[barrel.addon] || 0 }
             ];
         }) : [];
 
@@ -150,8 +150,8 @@ Module.loadTankDefinitions = () => {
             { offset: 64, type: "u32", value: tank.levelRequirement || 0 },
             { offset: 76, type: "u8", value: Number(tank.sides === 4) },
             { offset: 93, type: "u8", value: Number(tank.sides === 16) },
-            { offset: 96, type: "u32", value: ADDONMAP.addons[tank.preAddon] || 0 },
-            { offset: 100, type: "u32", value: ADDONMAP.addons[tank.postAddon] || 0 },
+            { offset: 96, type: "u32", value: ADDON_MAP.tankAddons[tank.preAddon] || 0 },
+            { offset: 100, type: "u32", value: ADDON_MAP.tankAddons[tank.postAddon] || 0 },
         ];
 
         $.writeStruct(ptr, fields);
@@ -265,17 +265,17 @@ Module.todo.push([(dependency, servers, tanks) => {
     
     parser.addCodeElementParser(null, function({ index, bytes }) {
         switch(index) {
-            case loadChangelogOriginal.i32(): // we only need the part where it checks if the changelog is already loaded to avoid too many import calls
+            case originalLoadChangelog.i32(): // we only need the part where it checks if the changelog is already loaded to avoid too many import calls
                 return new Uint8Array([
                     ...bytes.subarray(0, MOD_CONFIG.wasmFunctionHookOffset.changelog),
                     OP_CALL, ...VarUint32ToArray(loadChangelog.i32()),
-                    OP_END,
+                    ...bytes.subarray(MOD_CONFIG.wasmFunctionHookOffset.changelog)
                   ]);
-            case loadGamemodeButtonsOriginal.i32(): // we only need the part where it checks if the buttons are already loaded to avoid too many import calls
+            case originalLoadGamemodeButtons.i32(): // we only need the part where it checks if the buttons are already loaded to avoid too many import calls
                 return new Uint8Array([
                     ...bytes.subarray(0, MOD_CONFIG.wasmFunctionHookOffset.gamemodeButtons),
                     OP_CALL, ...VarUint32ToArray(loadGamemodeButtons.i32()),
-                    OP_END
+                    ...bytes.subarray(MOD_CONFIG.wasmFunctionHookOffset.gamemodeButtons)
                 ]);
             case originalGetTankDef.i32(): // we modify this to call a js function which then returns the tank def ptr from a table
                 return new Uint8Array([

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const server = http.createServer((req, res) => {
                 if (!auth) return;
                 util.saveToVLog("Authentication attempt");
                 return auth.handleInteraction(req, res);
-            case "/tankdefs":
+            case "/tanks":
                 res.writeHead(200);
                 return res.end(JSON.stringify(TankDefinitions));
             case "/servers":


### PR DESCRIPTION
### Why:
To be able to load tankdefs dynmically from the server

### Summarize what's being changed (include any screenshots, code, or other media if available):
- make /tanks endpoint to deliver tankdefs from server to client
- load tankdefs on the client into memory

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

Notes / Limitations:
- Custom Addons
- Tier 5+ Upgrades (More tiers than default get displayed weirdly on tankwheel, works normal otherwise though)