### PR TITLE
Minor patches(#44,#49,#50,#2, #4)

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -59,8 +59,21 @@ class WSWriterStream extends Writer {
         this.ws = ws;
     }
 
+    protected _at: number = 0;
+
+    protected get at() {
+        return this._at;
+    }
+
+    protected set at(v) {
+        if (v + 5 >= Writer.OUTPUT_BUFFER.length) {
+            this.ws.send(Writer.OUTPUT_BUFFER.subarray(0, v), {fin: false});
+            this._at = 0;
+        } else this._at = v;
+    }
+
     public send() {
-        return this.ws.send(this.write());
+        this.ws.send(this.write());
     }
 }
 

--- a/src/Coder/Writer.ts
+++ b/src/Coder/Writer.ts
@@ -21,13 +21,6 @@ import { writtenBufferChunkSize } from "../config";
 /**
  * UNDOCUMENTED FILE
  **/
-// TODO(ABC):
-// Code a compressor (The previous was not OOP and used lz4js code)
-// If this code gets out of bounds (only happens if you play around with dev too much), the server crashes [better than out of bounds r/w].
-// 
-// TEMP FIX - 2022/11/11:
-//   OUTPUT_BUFFER now gets resized if running out of space for the packet
-let OUTPUT_BUFFER = Buffer.alloc(writtenBufferChunkSize);
 
 const convo = new ArrayBuffer(4);
 const i32 = new Int32Array(convo);
@@ -42,37 +35,51 @@ const endianSwap = (num: number) =>
     ((num >> 24) & 0xff);
 
 export default class Writer {
-    private _at: number = 0;
+    // TODO(ABC):
+    // Code a compressor (The previous was not OOP and used lz4js code)
+    // If this code gets out of bounds (only happens if you play around with dev too much), the server crashes [better than out of bounds r/w].
+    // 
+    // TEMP FIX - 2022/11/11:
+    //   OUTPUT_BUFFER now gets resized if running out of space for the packet
+    //
+    // TEMP FIX 2 - 2022/11/13:
+    //   OUTPUT_BUFFER gets sent out in chunks (see Client.ts for more info)
+    protected static OUTPUT_BUFFER = Buffer.alloc(50);
+    protected _at: number = 0;
 
-    private get at() {
+    protected get at() {
         return this._at;
     }
 
-    private set at(v) {
+    protected set at(v) {
         this._at = v;
 
-        if (OUTPUT_BUFFER.length <= this._at + 5) {
-            const newBuffer = Buffer.alloc(OUTPUT_BUFFER.length + writtenBufferChunkSize);
-            newBuffer.set(OUTPUT_BUFFER, 0);
+        if (Writer.OUTPUT_BUFFER.length <= this._at + 5) {
+            const newBuffer = Buffer.alloc(Writer.OUTPUT_BUFFER.length + writtenBufferChunkSize);
+            newBuffer.set(Writer.OUTPUT_BUFFER, 0);
 
-            OUTPUT_BUFFER = newBuffer;
+            Writer.OUTPUT_BUFFER = newBuffer;
         }
     }
 
     public u8(val: number) {
-        OUTPUT_BUFFER.writeUInt8(val >>> 0 & 0xFF, this.at++);
+        Writer.OUTPUT_BUFFER.writeUInt8(val >>> 0 & 0xFF, this.at);
+        this.at += 1;
         return this;
     }
     public u16(val: number) {
-        OUTPUT_BUFFER.writeUint16LE(val >>> 0 & 0xFFFF, (this.at += 2) - 2);
+        Writer.OUTPUT_BUFFER.writeUint16LE(val >>> 0 & 0xFFFF, this.at);
+        this.at += 2;
         return this;
     }
     public u32(val: number) {
-        OUTPUT_BUFFER.writeUint32LE(val >>> 0, (this.at += 4) - 4);
+        Writer.OUTPUT_BUFFER.writeUint32LE(val >>> 0, this.at);
+        this.at += 4;
         return this;
     }
     public float(val: number) {
-        OUTPUT_BUFFER.writeFloatLE(val, (this.at += 4) - 4);
+        Writer.OUTPUT_BUFFER.writeFloatLE(val, this.at);
+        this.at += 4;
         return this;
     }
     public vf(val: number) {
@@ -87,7 +94,8 @@ export default class Writer {
             let part = val;
             val >>>= 7;
             if (val) part |= 0x80;
-            OUTPUT_BUFFER.writeUint8(part >>> 0 & 0xFF, this.at++);
+            Writer.OUTPUT_BUFFER.writeUint8(part >>> 0 & 0xFF, this.at);
+            this.at += 1;
         } while (val);
 
         // OUTPUT_BUFFER.set(buf.subarray(0, at), (this.at += at) - at);
@@ -98,11 +106,13 @@ export default class Writer {
         return this.vu((0 - (val < 0 ? 1 : 0)) ^ (val << 1)); // varsint trick
     }
     public bytes(buffer: Uint8Array) {
-        OUTPUT_BUFFER.set(buffer, (this.at += buffer.byteLength) - buffer.byteLength)
+        Writer.OUTPUT_BUFFER.set(buffer, this.at);
+        this.at += buffer.byteLength;
         return this;
     }
     public raw(...data: number[]) {
-        OUTPUT_BUFFER.set(data, (this.at += data.length) - data.length)
+        Writer.OUTPUT_BUFFER.set(data, this.at)
+        this.at += data.length;
         return this;
     }
     public radians(radians: number) {
@@ -113,7 +123,13 @@ export default class Writer {
         return this.vi(degrees * 64)
     }
     public stringNT(str: string) {
-        this.at += Encoder.encodeInto(str + "\x00", OUTPUT_BUFFER.subarray(this.at)).written || 0;
+        const bytes = Encoder.encode(str + "\x00");
+        // TODO(ABC): See line 69 Client.ts
+        // rn it sends string out in bytes, send it all at once without messing up the chunking
+        for (let i = 0; i < bytes.byteLength; ++i) {
+            Writer.OUTPUT_BUFFER[this.at] = bytes[i];
+            this.at += 1;
+        }
 
         return this;
     }
@@ -122,8 +138,8 @@ export default class Writer {
         return this.vu(entity.hash).vu(entity.id);
     }
     public write(slice: boolean=false) {
-        if (slice) return OUTPUT_BUFFER.slice(0, this.at);
+        if (slice) return Writer.OUTPUT_BUFFER.slice(0, this.at);
         
-        return OUTPUT_BUFFER.subarray(0, this.at);
+        return Writer.OUTPUT_BUFFER.subarray(0, this.at);
     }
 }

--- a/src/Const/DevTankDefinitions.ts
+++ b/src/Const/DevTankDefinitions.ts
@@ -1466,13 +1466,13 @@ const DevTankDefinitions: TankDefinition[] = [
         levelRequirement: 0,
         upgrades: [],
         flags: {
-            invisibility: false,
+            invisibility: true,
             zoomAbility: false,
             devOnly: true
         },
         visibilityRateShooting: 0.0,
         visibilityRateMoving: 0.0,
-        invisibilityRate: 1,
+        invisibilityRate: 1.0,
         fieldFactor: 0.3,
         absorbtionFactor: 0,
         speed: 3,

--- a/src/Entity/AI.ts
+++ b/src/Entity/AI.ts
@@ -120,10 +120,10 @@ export class AI {
 
             // If the AI already has a valid target within view distance, it's not necessary to find a new one
             
-            if (team !== this.target.relations.values.team) { // Check if the target is on the same team. If it is, need to find a new one
-            
+            // Make sure the target hasn't changed teams, and is existant (sides != 0)
+            if (team !== this.target.relations.values.team && this.target.physics.values.sides !== 0) {
+                // confirm its within range
                 const targetDistSq = (this.target.position.values.x - rootPos.x) ** 2 + (this.target.position.values.y - rootPos.y) ** 2;
-
                 if (this.targetFilter(this.target) && targetDistSq < ( this.viewRange ** 2 ) * 2) return this.target; // this range is inaccurate i think
                 
             }
@@ -132,7 +132,6 @@ export class AI {
         
 
         // const entities = this.game.entities.inner.slice(0, this.game.entities.lastId);
-
         const root = this.owner.rootParent === this.owner && this.owner.relations.values.owner instanceof ObjectEntity ? this.owner.relations.values.owner : this.owner.rootParent;
         const entities = this.viewRange === Infinity ? this.game.entities.inner.slice(0, this.game.entities.lastId) : this.game.entities.collisionManager.retrieve(root.position.values.x, root.position.values.y, this.viewRange, this.viewRange);
 
@@ -143,15 +142,15 @@ export class AI {
 
             const entity = entities[i];
 
-            if (! (entity instanceof LivingEntity) ) continue; // Check if the target is living
+            if (!(entity instanceof LivingEntity) ) continue; // Check if the target is living
 
             if (entity.physics.values.objectFlags & ObjectFlags.base) continue; // Check if the target is a base
 
             if (!(entity.relations.values.owner === null || !(entity.relations.values.owner instanceof ObjectEntity))) continue; // Don't target entities who have an object owner
-
-            if (!this.targetFilter(entity)) continue; // Custom check
             
             if (entity.relations.values.team === team || entity.physics.values.sides === 0) continue;
+
+            if (!this.targetFilter(entity)) continue; // Custom check
 
             if (entity instanceof TankBody) return this.target = entity;
 

--- a/src/Entity/Boss/AbstractBoss.ts
+++ b/src/Entity/Boss/AbstractBoss.ts
@@ -122,7 +122,7 @@ export default class AbstractBoss extends LivingEntity {
         this.position.values.x = x;
         this.position.values.y = y;
         
-        this.relations.values.team = this.cameraEntity;
+        this.relations.values.team = null;
 
         this.physics.values.absorbtionFactor = 0.05;
         this.position.values.motion |= MotionFlags.absoluteRotation;

--- a/src/Entity/Misc/Dominator.ts
+++ b/src/Entity/Misc/Dominator.ts
@@ -86,7 +86,7 @@ export default class Dominator extends TankBody {
     public onDeath(killer: LivingEntity) {
         if (this.relations.values.team === this.game.arena) {
             this.relations.team = killer.relations.values.team || this.game.arena;
-            this.style.color = killer.relations.values.team?.team?.teamColor || killer.style.values.color;
+            this.style.color = this.relations.team.team?.teamColor || killer.style.values.color;
         } else {
             this.relations.team = this.game.arena
             this.style.color = this.game.arena.team.teamColor;

--- a/src/Entity/Object.ts
+++ b/src/Entity/Object.ts
@@ -327,24 +327,19 @@ export default class ObjectEntity extends Entity {
     }
 
     /** Returns the true world position (even for objects who have parents). */
-    public getWorldPosition(): VectorAbstract {
-        let x = this.position.values.x;
-        let y = this.position.values.y;
+    public getWorldPosition(): Vector {
+        let pos = new Vector(this.position.values.x, this.position.values.y);
 
         let entity: ObjectEntity = this;
-        let absolute = false;
         while (entity.relations.values.parent instanceof ObjectEntity) {
-            // if (!absolute) {
-                x *= Math.cos(entity.position.values.angle);
-                y *= Math.sin(entity.position.values.angle);
-            // } 
+            
+            if (!(entity.relations.values.parent.position.values.motion & MotionFlags.absoluteRotation)) pos.angle += entity.position.values.angle;
             entity = entity.relations.values.parent;
-            x += entity.position.values.x;
-            y += entity.position.values.y;
-            // if (entity.position.values.motion & MotionFlags.absoluteRotation) absolute = true;
+            pos.x += entity.position.values.x;
+            pos.y += entity.position.values.y;
         }
 
-        return { x, y };
+        return pos;
     }
 
     public tick(tick: number) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,8 +31,11 @@ export const tps: number = 1000 / mspt;
 /** Max connections per ip. -1 = no limit */
 export const connectionsPerIp: number = -1;
 
-/** Max packet size (HARD LIMIT), not the max read / write size */
+/** Max incoming packet size (HARD LIMIT), not the max read / write size */
 export const wssMaxMessageSize: number = 4096; // 4 kb
+
+/** Output Chunk Size for the Writer (during resize) */
+export const writtenBufferChunkSize = Buffer.poolSize || 2048;
 
 /** Host id to be sent to client. */
 export const host: string = process.env.SERVER_INFO || (process.env.NODE_ENV === "development" ? "localhost" : "");


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes #2, #44, #49, and #50.

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
1. #2) Added 00 packet chunking (idea by Nulled) to split up larger packets into multiple smaller ones. Along with that, made the `OUTPUT_BUFFER` resize if running out of space.
2. #44) Makes AI check if the target's sides != 0, before continuing to use it as a target.
3. #49) Set the spectator tank to actually use the invisibility meta data described earlier (someone forgot to do this previously)
4. #50) Set fallen bosses to have no team, and set non teamed dominators to default to the Arena
5. #4) Calculates barrel pos correctly - algorithms were off
### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

