### PR TITLE
fix #58

### DIFF
--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -204,7 +204,7 @@ export default class TankBody extends LivingEntity implements BarrelBase {
         if (!(this.cameraEntity instanceof Camera)) return this.cameraEntity.delete();
 
         this.cameraEntity.spectatee = killer;
-        this.cameraEntity.camera.FOV = 0.4;
+        this.cameraEntity.camera.FOV = killer.camera?.FOV || 0.4;
         this.cameraEntity.camera.killedBy = (killer.name && killer.name.values.name) || "";
     }
 


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes #58

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
If a client is killed, their FOV will be set to their killer's FOV. If the killer dies before them (thus their camera being null), then automatically revert to 0.4 (may not be accurate in normal Diep.io).

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no differences in gameplay

