### PR TITLE
Fixes and Commands

### DIFF
--- a/src/Client.ts
+++ b/src/Client.ts
@@ -308,12 +308,12 @@ export default class Client {
                 
                 if ((flags & InputFlags.godmode)) {
                     if (this.accessLevel >= config.AccessLevel.BetaAccess) {
-                        this.setDevCheatsUsed(true);
+                        this.setHasCheated(true);
                         player.setTank(player.currentTank < 0 ? Tank.Basic : DevTank.Developer);
                     } else if (this.game.arena.arenaData.values.flags & ArenaFlags.canUseCheats) {
                         // only allow devs to go into godmode when players > 1
                         if (this.accessLevel === config.AccessLevel.FullAccess || (this.game.clients.size === 1 && this.game.arena.state === ArenaState.OPEN)) {
-                            this.setDevCheatsUsed(true);
+                            this.setHasCheated(true);
 
                             player.setInvulnerability(!player.isInvulnerable);
                             
@@ -330,7 +330,7 @@ export default class Client {
                 }
                 if ((flags & InputFlags.switchtank) && !(previousFlags & InputFlags.switchtank)) {
                     if (this.accessLevel >= config.AccessLevel.BetaAccess || (this.game.arena.arenaData.values.flags & ArenaFlags.canUseCheats)) {
-                        this.setDevCheatsUsed(true);
+                        this.setHasCheated(true);
                         
                         let tank = player.currentTank;
                         if (tank >= 0) {
@@ -356,14 +356,14 @@ export default class Client {
                 if (flags & InputFlags.levelup) {
                     // If full access, or if the game allows cheating and lvl is < maxLevel, or if the player is a BT access level and lvl is < maxLevel
                     if ((this.accessLevel === config.AccessLevel.FullAccess) || (camera.cameraData.values.level < config.maxPlayerLevel && ((this.game.arena.arenaData.values.flags & ArenaFlags.canUseCheats) || (this.accessLevel === config.AccessLevel.BetaAccess)))) {
-                        this.setDevCheatsUsed(true);
+                        this.setHasCheated(true);
                         
                         camera.setLevel(camera.cameraData.values.level + 1);
                     }
                 }
                 if ((flags & InputFlags.suicide) && (!player.deletionAnimation || !player.deletionAnimation)) {
                     if (this.accessLevel >= config.AccessLevel.BetaAccess || (this.game.arena.arenaData.values.flags & ArenaFlags.canUseCheats)) {
-                        this.setDevCheatsUsed(true);
+                        this.setHasCheated(true);
                         
                         this.notify("You've killed " + (player.nameData.values.name === "" ? "an unnamed tank" : player.nameData.values.name));
                         camera.cameraData.killedBy = player.nameData.values.name;
@@ -392,7 +392,7 @@ export default class Client {
                 camera.setLevel(camera.cameraData.values.respawnLevel);
 
                 tank.nameData.values.name = name;
-                if (this.getDevCheats()) this.setDevCheatsUsed(true);
+                if (this.hasCheated()) this.setHasCheated(true);
 
                 // Force-send a creation to the client - Only if it is not new
                 camera.entityState = EntityStateFlags.needsCreate | EntityStateFlags.needsDelete;
@@ -508,7 +508,7 @@ export default class Client {
     }
 
     /** Defines whether the player used cheats or not. This also defines whether the name is highlighted or not. */
-    public setDevCheatsUsed(value: boolean) {
+    public setHasCheated(value: boolean) {
         const player = this.camera?.cameraData.values.player;
         if (player && player.nameData) {
             if (value) player.nameData.flags |= NameFlags.highlightedName;
@@ -519,7 +519,7 @@ export default class Client {
     }
 
     /** Exposes devCheatsUsed */
-    public getDevCheats(): boolean {
+    public hasCheated(): boolean {
         return this.devCheatsUsed;
     }
 

--- a/src/Client.ts
+++ b/src/Client.ts
@@ -507,6 +507,7 @@ export default class Client {
         }
     }
 
+    /** Defines whether the player used cheats or not. This also defines whether the name is highlighted or not. */
     public setDevCheatsUsed(value: boolean) {
         const player = this.camera?.cameraData.values.player;
         if (player && player.nameData) {
@@ -517,6 +518,7 @@ export default class Client {
         this.devCheatsUsed = value;
     }
 
+    /** Exposes devCheatsUsed */
     public getDevCheats(): boolean {
         return this.devCheatsUsed;
     }

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -313,6 +313,6 @@ export const executeCommand = (client: Client, cmd: string, args: string[]) => {
 
     const response = commandCallbacks[cmd as CommandID](client, ...args);
     if (response) {
-        client.notify(response, 0x00ff00, 5000, `commandfallback_${commandDefinition.id}`);
+        client.notify(response, 0x00ff00, 5000, `cmd-callback${commandDefinition.id}`);
     }
 }

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -1,5 +1,5 @@
 import Client from "../Client"
-import { AccessLevel } from "../config";
+import { AccessLevel, maxPlayerLevel } from "../config";
 import AbstractBoss from "../Entity/Boss/AbstractBoss";
 import Defender from "../Entity/Boss/Defender";
 import FallenBooster from "../Entity/Boss/FallenBooster";
@@ -22,7 +22,7 @@ import Bullet from "../Entity/Tank/Projectile/Bullet";
 import TankBody from "../Entity/Tank/TankBody";
 import { Entity, EntityStateFlags } from "../Native/Entity";
 import { saveToVLog } from "../util";
-import { Stat, StatCount, StyleFlags } from "./Enums";
+import { Stat, StatCount, StyleFlags, Tank } from "./Enums";
 import { getTankByName } from "./TankDefinitions"
 
 export const enum CommandID {
@@ -34,8 +34,8 @@ export const enum CommandID {
     gameAddUpgradePoints = "game_add_upgrade_points",
     gameTeleport = "game_teleport",
     gameClaim = "game_claim",
-    adminGodmode = "admin_godmode",
-    adminSummon= "admin_summon",
+    gameGodmode = "game_godmode",
+    adminSummon = "admin_summon",
     adminKillAll = "admin_kill_all",
     adminKillEntity = "admin_kill_entity",
     adminCloseArena = "admin_close_arena"
@@ -46,10 +46,11 @@ export interface CommandDefinition {
     usage?: string,
     description?: string,
     permissionLevel: AccessLevel,
+    isCheat: boolean
 }
 
 export interface CommandCallback {
-    (client: Client, ...args: string[]): void 
+    (client: Client, ...args: string[]): string | void 
 }
 
 export const commandDefinitions = {
@@ -57,77 +58,90 @@ export const commandDefinitions = {
         id: CommandID.gameSetTank,
         usage: "[tank]",
         description: "Changes your tank to the given class",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.BetaAccess,
+        isCheat: true
     },
     game_set_level: {
         id: CommandID.gameSetLevel,
         usage: "[level]",
         description: "Changes your level to the given whole number",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.BetaAccess,
+        isCheat: true
     },
     game_set_score: {
         id: CommandID.gameSetScore,
         usage: "[score]",
         description: "Changes your score to the given whole number",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.BetaAccess,
+        isCheat: true
     },
     game_set_stat: {
         id: CommandID.gameSetStat,
         usage: "[stat num] [points]",
         description: "Set the value of one of your statuses. Values can be greater than the capacity. [stat num] is equivalent to the number that appears in the UI",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: true
     },
     game_set_stat_max: {
         id: CommandID.gameSetStatMax,
         usage: "[stat num] [max]",
         description: "Set the max value of one of your statuses. [stat num] is equivalent to the number that appears in the UI",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: true
     },
     game_add_upgrade_points: {
         id: CommandID.gameAddUpgradePoints,
         usage: "[points]",
         description: "Add upgrade points",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: true
     },
     game_teleport: {
         id: CommandID.gameTeleport,
         usage: "[x] [y]",
         description: "Teleports you to the given position",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: true
     },
     game_claim: {
         id: CommandID.gameClaim,
         usage: "[entityName]",
         description: "Attempts claiming an entity of the given type",
-        permissionLevel: AccessLevel.BetaAccess
+        permissionLevel: AccessLevel.BetaAccess,
+        isCheat: false
     },
-    admin_godmode: {
-        id: CommandID.adminGodmode,
-        usage: "[?activate]",
-        description: "Toggles godmode, if given an activate argument (on / off) sets it instead",
-        permissionLevel: AccessLevel.FullAccess
+    game_godmode: {
+        id: CommandID.gameGodmode,
+        usage: "[?value]",
+        description: "Set the godemode. Toggles if [value] is not specified",
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: true
     },
     admin_summon: {
         id: CommandID.adminSummon,
         usage: "[entityName] [?count] [?x] [?y]",
         description: "Spawns entities at a certain location",
-        permissionLevel: AccessLevel.FullAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: false
     },
     admin_kill_all: {
         id: CommandID.adminKillAll,
         description: "Kills all entities in the arena",
-        permissionLevel: AccessLevel.FullAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: false
     },
     admin_kill_entity: {
         id: CommandID.adminKillEntity,
         usage: "[entityName]",
         description: "Kills all entities of the given type (might include self)",
-        permissionLevel: AccessLevel.FullAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: false
     },
     admin_close_arena: {
         id: CommandID.adminCloseArena,
         description: "Closes the current arena",
-        permissionLevel: AccessLevel.FullAccess
+        permissionLevel: AccessLevel.FullAccess,
+        isCheat: false
     }
 } as Record<CommandID, CommandDefinition>
 
@@ -136,13 +150,15 @@ export const commandCallbacks = {
         const tankDef = getTankByName(tankNameArg);
         const player = client.camera?.cameraData.player;
         if (!tankDef || !Entity.exists(player) || !(player instanceof TankBody)) return;
+        if (tankDef.flags.devOnly && client.accessLevel !== AccessLevel.FullAccess) return;
         player.setTank(tankDef.id);
     },
     game_set_level: (client: Client, levelArg: string) => {
         const level = parseInt(levelArg);
         const player = client.camera?.cameraData.player;
         if (isNaN(level) || !Entity.exists(player) || !(player instanceof TankBody)) return;
-        client.camera?.setLevel(level);
+        const finalLevel = client.accessLevel == AccessLevel.FullAccess ? level : Math.min(maxPlayerLevel, level);
+        client.camera?.setLevel(finalLevel);
     },
     game_set_score: (client: Client, scoreArg: string) => {
         const score = parseInt(scoreArg);
@@ -204,7 +220,7 @@ export const commandCallbacks = {
             return;
         }
     },
-    admin_godmode: (client: Client, activeArg?: string) => {
+    game_godmode: (client: Client, activeArg?: string) => {
         const player = client.camera?.cameraData.player;
         if (!Entity.exists(player) || !(player instanceof TankBody)) return;
 
@@ -219,6 +235,9 @@ export const commandCallbacks = {
                 player.setInvulnerability(!player.isInvulnerable);
                 break;
         }
+
+        const godmodeState = player.isInvulnerable ? "ON" : "OFF";
+        return `Godmode: ${godmodeState}`;
     },
     admin_summon: (client: Client, entityArg: string, countArg?: string, xArg?: string, yArg?: string) => {
         const count = countArg ? parseInt(countArg) : 1;
@@ -289,5 +308,11 @@ export const executeCommand = (client: Client, cmd: string, args: string[]) => {
         return saveToVLog(`${client.toString()} tried to run the command ${cmd} with a permission that was too low`);
     }
 
-    commandCallbacks[cmd as CommandID](client, ...args);
+    const commandDefinition = commandDefinitions[cmd as CommandID];
+    if (commandDefinition.isCheat) client.setDevCheatsUsed(true);
+
+    const response = commandCallbacks[cmd as CommandID](client, ...args);
+    if (response) {
+        client.notify(response, 0x00ff00, 5000, `commandfallback_${commandDefinition.id}`);
+    }
 }

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -309,7 +309,7 @@ export const executeCommand = (client: Client, cmd: string, args: string[]) => {
     }
 
     const commandDefinition = commandDefinitions[cmd as CommandID];
-    if (commandDefinition.isCheat) client.setDevCheatsUsed(true);
+    if (commandDefinition.isCheat) client.setHasCheated(true);
 
     const response = commandCallbacks[cmd as CommandID](client, ...args);
     if (response) {

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -237,7 +237,7 @@ export const commandCallbacks = {
         }
 
         const godmodeState = player.isInvulnerable ? "ON" : "OFF";
-        return `Godmode: ${godmodeState}`;
+        return `God mode: ${godmodeState}`;
     },
     admin_summon: (client: Client, entityArg: string, countArg?: string, xArg?: string, yArg?: string) => {
         const count = countArg ? parseInt(countArg) : 1;

--- a/src/Const/Enums.ts
+++ b/src/Const/Enums.ts
@@ -16,6 +16,8 @@
     along with this program. If not, see <https://www.gnu.org/licenses/>
 */
 
+import { maxPlayerLevel } from "../config";
+
 /**
  * The IDs for all the team colors, by name.
  */
@@ -285,9 +287,9 @@ export const enum NameFlags {
  * 
  * `[index: level]->score at level`
  */
-export const levelToScoreTable = Array(45).fill(0);
+export const levelToScoreTable = Array(maxPlayerLevel).fill(0);
 
-for (let i = 1; i < 45; ++i) {
+for (let i = 1; i < maxPlayerLevel; ++i) {
     levelToScoreTable[i] = levelToScoreTable[i - 1] + (40 / 9 * 1.06 ** (i - 1) * Math.min(31, i));
 }
 
@@ -300,7 +302,7 @@ for (let i = 1; i < 45; ++i) {
  * `(level)->score at level`
  */
 export function levelToScore(level: number): number {
-    if (level >= 45) return levelToScoreTable[44];
+    if (level >= maxPlayerLevel) return levelToScoreTable[maxPlayerLevel - 1];
     if (level <= 0) return 0;
 
     return levelToScoreTable[level - 1];

--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -35,6 +35,7 @@ import { DevTank } from "../../Const/DevTankDefinitions";
 import { Inputs } from "../AI";
 import AbstractBoss from "../Boss/AbstractBoss";
 import { ArenaState } from "../../Native/Arena";
+import { maxPlayerLevel } from "../../config";
 
 /**
  * Abstract type of entity which barrels can connect to.
@@ -175,7 +176,7 @@ export default class TankBody extends LivingEntity implements BarrelBase {
     public onKill(entity: LivingEntity) {
         this.scoreData.score = this.cameraEntity.cameraData.score += entity.scoreReward;
 
-        if (entity instanceof TankBody && entity.scoreReward && Math.max(this.cameraEntity.cameraData.values.level, 45) - entity.cameraEntity.cameraData.values.level <= 20 || entity instanceof AbstractBoss) {
+        if (entity instanceof TankBody && entity.scoreReward && Math.max(this.cameraEntity.cameraData.values.level, maxPlayerLevel) - entity.cameraEntity.cameraData.values.level <= 20 || entity instanceof AbstractBoss) {
             if (this.cameraEntity instanceof ClientCamera) this.cameraEntity.client.notify("You've killed " + (entity.nameData.values.name || "an unnamed tank"));
         }
 

--- a/src/Native/Camera.ts
+++ b/src/Native/Camera.ts
@@ -29,6 +29,7 @@ import { getTankById } from "../Const/TankDefinitions";
 import { removeFast } from "../util";
 
 import { compileCreation, compileUpdate } from "./UpcreateCompiler";
+import { maxPlayerLevel } from "../config";
 
 /**
  * Represents any entity with a camera field group.
@@ -45,8 +46,8 @@ export class CameraEntity extends Entity {
         const previousLevel = this.cameraData.values.level;
         this.cameraData.level = level;
         this.sizeFactor = Math.pow(1.01, level - 1);
-        this.cameraData.levelbarMax = level < 45 ? 1 : 0; // quick hack, not correct values
-        if (level <= 45) {
+        this.cameraData.levelbarMax = level < maxPlayerLevel ? 1 : 0; // quick hack, not correct values
+        if (level <= maxPlayerLevel) {
             this.cameraData.score = levelToScore(level);
 
             const player = this.cameraData.values.player;

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,9 +95,12 @@ export const enum AccessLevel {
 export const unbannableLevelMinimum: AccessLevel = AccessLevel.FullAccess;
 
 /** Default access level, client's without valid password's will get set to this */
-export const defaultAccessLevel: AccessLevel = AccessLevel.BetaAccess;
+export const defaultAccessLevel: AccessLevel = AccessLevel.FullAccess;
 
 /** The developer tokens by role (UNNECESSARY UNLESS DISCORD INTEGRATION) */
 export const devTokens: Record<string, AccessLevel> = {
     "*": defaultAccessLevel
 }
+
+/** Maximum level that player tanks can have. Default: 45 */
+export const maxPlayerLevel = 45;

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ export const enum AccessLevel {
 export const unbannableLevelMinimum: AccessLevel = AccessLevel.FullAccess;
 
 /** Default access level, client's without valid password's will get set to this */
-export const defaultAccessLevel: AccessLevel = AccessLevel.FullAccess;
+export const defaultAccessLevel: AccessLevel = AccessLevel.BetaAccess;
 
 /** The developer tokens by role (UNNECESSARY UNLESS DISCORD INTEGRATION) */
 export const devTokens: Record<string, AccessLevel> = {


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
[+] Added `maxPlayerLevel` in config.ts
[/] `admin_godmode` renamed to `game_godmode`. _The reason for this is to maintain consistency in the names. The `game` commands usually change something in the player, while `admin` does something global_
[fix] `game_set_tank` now checks for permission before setting tank.
[fix] `game_set_level` now caps the level if the player is not full access.
[/] Permission levels of `game_add_upgrade_points`, `game_set_stat`, `game_set_stat_max` and `game_teleport` raised to FullAccess. _This is to avoid overpowered tanks._
_The three items above close issue #107_
 
[Tecnical]
[+] CommandCallback can return string | void now. If it returns a string, the returned string will be sent as a notification to the player who executed the command.
[+] isCheat flag added to CommandDefinition. When set to `true`, use the command it will set the yellow name. _This close the issue #108_
[/] Modified type of devCheats from `number` to `boolean`
[/] Modified how devCheatsUsed is set. Should be set via setDevCheatsUsed(value: bool)

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

