### PR TITLE
feat: Implement relative positioning for commands

### DIFF
--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -25,6 +25,8 @@ import { saveToVLog } from "../util";
 import { Stat, StatCount, StyleFlags, Tank } from "./Enums";
 import { getTankByName } from "./TankDefinitions"
 
+const RELATIVE_POS_REGEX = new RegExp(/~(-?\d+)?/);
+
 export const enum CommandID {
     gameSetTank = "game_set_tank",
     gameSetLevel = "game_set_level",
@@ -195,8 +197,8 @@ export const commandCallbacks = {
     game_teleport: (client: Client, xArg: string, yArg: string) => {
         const player = client.camera?.cameraData.player;
         if (!Entity.exists(player) || !(player instanceof ObjectEntity)) return;
-        const x = xArg.match(/~(-?\d+)?/) ? player.positionData.x + parseInt(xArg.slice(1) || "0") : parseInt(xArg);
-        const y = yArg.match(/~(-?\d+)?/) ? player.positionData.y + parseInt(yArg.slice(1) || "0") : parseInt(yArg);
+        const x = xArg.match(RELATIVE_POS_REGEX) ? player.positionData.x + parseInt(xArg.slice(1) || "0") : parseInt(xArg);
+        const y = yArg.match(RELATIVE_POS_REGEX) ? player.positionData.y + parseInt(yArg.slice(1) || "0") : parseInt(yArg);
         if (isNaN(x) || isNaN(y)) return;
         player.positionData.x = x;
         player.positionData.y = y;
@@ -242,16 +244,16 @@ export const commandCallbacks = {
     },
     admin_summon: (client: Client, entityArg: string, countArg?: string, xArg?: string, yArg?: string) => {
         const count = countArg ? parseInt(countArg) : 1;
-        let x = parseInt(xArg || "0");
-        let y = parseInt(yArg || "0");
+        let x = parseInt(xArg || "0", 10);
+        let y = parseInt(yArg || "0", 10);
 
         const player = client.camera?.cameraData.player;
         if (Entity.exists(player) && player instanceof ObjectEntity) {
-            if (xArg && xArg.match(/~(-?\d+)?/)) {
-                x = player.positionData.x + parseInt(xArg.slice(1) || "0");
+            if (xArg && xArg.match(RELATIVE_POS_REGEX)) {
+                x = player.positionData.x + parseInt(xArg.slice(1) || "0", 10);
             }
-            if (yArg && yArg.match(/~(-?\d+)?/)) {
-                y = player.positionData.y + parseInt(yArg.slice(1) || "0");
+            if (yArg && yArg.match(RELATIVE_POS_REGEX)) {
+                y = player.positionData.y + parseInt(yArg.slice(1) || "0", 10);
             }
         }
 

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -197,8 +197,8 @@ export const commandCallbacks = {
     game_teleport: (client: Client, xArg: string, yArg: string) => {
         const player = client.camera?.cameraData.player;
         if (!Entity.exists(player) || !(player instanceof ObjectEntity)) return;
-        const x = xArg.match(RELATIVE_POS_REGEX) ? player.positionData.x + parseInt(xArg.slice(1) || "0") : parseInt(xArg);
-        const y = yArg.match(RELATIVE_POS_REGEX) ? player.positionData.y + parseInt(yArg.slice(1) || "0") : parseInt(yArg);
+        const x = xArg.match(RELATIVE_POS_REGEX) ? player.positionData.x + parseInt(xArg.slice(1) || "0", 10) : parseInt(xArg, 10);
+        const y = yArg.match(RELATIVE_POS_REGEX) ? player.positionData.y + parseInt(yArg.slice(1) || "0", 10) : parseInt(yArg, 10);
         if (isNaN(x) || isNaN(y)) return;
         player.positionData.x = x;
         player.positionData.y = y;

--- a/src/Const/Commands.ts
+++ b/src/Const/Commands.ts
@@ -193,10 +193,11 @@ export const commandCallbacks = {
         camera.statsAvailable += points;
     },
     game_teleport: (client: Client, xArg: string, yArg: string) => {
-        const x = parseInt(xArg);
-        const y = parseInt(yArg);
         const player = client.camera?.cameraData.player;
-        if (isNaN(x) || isNaN(y) || !Entity.exists(player) || !(player instanceof TankBody)) return;
+        if (!Entity.exists(player) || !(player instanceof ObjectEntity)) return;
+        const x = xArg.match(/~(-?\d+)?/) ? player.positionData.x + parseInt(xArg.slice(1) || "0") : parseInt(xArg);
+        const y = yArg.match(/~(-?\d+)?/) ? player.positionData.y + parseInt(yArg.slice(1) || "0") : parseInt(yArg);
+        if (isNaN(x) || isNaN(y)) return;
         player.positionData.x = x;
         player.positionData.y = y;
         player.setVelocity(0, 0);
@@ -241,8 +242,19 @@ export const commandCallbacks = {
     },
     admin_summon: (client: Client, entityArg: string, countArg?: string, xArg?: string, yArg?: string) => {
         const count = countArg ? parseInt(countArg) : 1;
-        const x = parseInt(xArg || "");
-        const y = parseInt(yArg || "");
+        let x = parseInt(xArg || "0");
+        let y = parseInt(yArg || "0");
+
+        const player = client.camera?.cameraData.player;
+        if (Entity.exists(player) && player instanceof ObjectEntity) {
+            if (xArg && xArg.match(/~(-?\d+)?/)) {
+                x = player.positionData.x + parseInt(xArg.slice(1) || "0");
+            }
+            if (yArg && yArg.match(/~(-?\d+)?/)) {
+                y = player.positionData.y + parseInt(yArg.slice(1) || "0");
+            }
+        }
+
         const game = client.camera?.game;
         const TEntity = new Map([
             ["Defender", Defender],


### PR DESCRIPTION
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Closes [issue link](https://github.com/ABCxFF/diepcustom/issues/122)
Allows more accurate positioning of summon and teleport

### Summarize what's being changed (include any screenshots, code, or other media if available):
Uses relative entity position of player by replacing "~" in the command args with the player position
Examples:
- teleport xArg = "~", yArg = "~100" will add 100 units to the players y position
- summon defender at "~ ~-1000" will summon a defender at the player's x coordinate but offsets the y coordinate by -1000

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

