### PR TITLE
fix random crashing on first 0x00 packet

### DIFF
--- a/src/Native/Camera.ts
+++ b/src/Native/Camera.ts
@@ -163,12 +163,6 @@ export default class ClientCamera extends CameraEntity {
         const updates: Entity[] = [];
         const creations: Entity[] = [];
 
-        // Yeah.
-        if (this.view.length === 0) {
-            creations.push(this.game.arena, this);
-            this.view.push(this.game.arena, this);
-        }
-
         const fov = this.cameraData.values.FOV;
         const width = (1920 / fov) / 1.5;
         const height = (1080 / fov) / 1.5;
@@ -232,6 +226,12 @@ export default class ClientCamera extends CameraEntity {
             if (!deletes[i].noDelete) this.removeFromView(deletes[i].id);
         }
 
+        // Yeah.
+        if (this.view.length === 0) {
+            creations.push(this.game.arena, this);
+            this.view.push(this.game.arena, this);
+        }
+        
         const entities = this.game.entities;
         for (const id of this.game.entities.otherEntities) {
             // TODO(speed)


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
No issue posted - though it could relate to #96 

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
The issue was the fact that entities in view were checked to see if they were updated.Arena has a special case for being added to the view, and that case is before the "is updated?" check. This caused a possible scenario where arena was both created and updated in the same packet

Updates are sent before creations, so this caused an issue. Instead of swapping updates and creation, ended up putting the special case for arena compilation after the "is updated?" check is complete.
### Confirm the following:
I have **NOT** tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

