### PR TITLE
Implementing serverside (net) color loading on the clientside

### DIFF
--- a/client/config.js
+++ b/client/config.js
@@ -250,7 +250,8 @@ const MOD_CONFIG = {
         "changelogLoaded": 168632,
         "tankDefinitions": 166572,
         "tankDefinitionsCount": 166576,
-        "commandList": 53064
+        "commandList": 53064,
+        "netColorTable": 49584
     },
     "wasmFunctionHookOffset": {
         "gamemodeButtons": 33,

--- a/client/loader.js
+++ b/client/loader.js
@@ -468,7 +468,7 @@ Module.todo.push([(dependency, servers, tanks) => {
     parser.addCodeElementParser(null, function({ index, bytes }) {
         const ptrPattern = VarUint32ToArray(MOD_CONFIG.memory.netColorTable);
         const geuPattern = [OP_I32_CONST, 19, OP_I32_GE_U];
-        const ltuPattern = [OP_I32_CONST, 19, OP_I32_LT_U]
+        const ltuPattern = [OP_I32_CONST, 19, OP_I32_LT_U];
         for(const idx of findConsecutiveSequenceIndex(bytes, ptrPattern)) {
             const arr = Array.from(bytes); // convert to normal array for splicing
             arr.splice(idx, ptrPattern.length, ...VarUint32ToArray(DYNAMIC_TOP_PTR + 4)); // using "empty" space

--- a/client/loader.js
+++ b/client/loader.js
@@ -198,7 +198,6 @@ Module.loadChangelog = (changelog) => {
 Module.loadColors = () => {
     if(!window.input || !Module.colors) return;
     for(const [idx, color] of Object.entries(Module.colors)) {
-        console.log(`net_replace_color ${idx} ${color}`)
         window.input.execute(`net_replace_color ${idx} ${color}`);
     }
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import GameServer from "./Game";
 import auth from "./Auth";
 import TankDefinitions from "./Const/TankDefinitions";
 import { commandDefinitions } from "./Const/Commands";
+import { ColorsHexCode } from "./Const/Enums";
 
 const PORT = config.serverPort;
 const ENABLE_API = config.enableApi && config.apiLocation;
@@ -58,6 +59,9 @@ const server = http.createServer((req, res) => {
             case "/commands":
                 res.writeHead(200);
                 return res.end(JSON.stringify(config.enableCommands ? Object.values(commandDefinitions) : []));
+            case "/colors":
+                res.writeHead(200);
+                return res.end(JSON.stringify(ColorsHexCode));
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Provides more color variety, also allows for forcefully changing default colors on the client.

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
Basically all it does is change the location of where netcolors are stored to remove the limitation of static array length. It also overwrite the limitation logic from >= kMaxColors to != kMaxColors; changed kMaxColors from 18 to -2. Also implemented an api endpoint api/colors to allow loading colors from the serverside, this may be deactivated by setting the reloadColorsInterval to -1.

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

