### PR TITLE
Implement more serverside utility fields on tankdefinitions

### DIFF
--- a/src/Const/TankDefinitions.ts
+++ b/src/Const/TankDefinitions.ts
@@ -95,6 +95,8 @@ export interface BarrelDefinition {
     canControlDrones?: boolean;
     /** Whether or not the barrel should always shoot (Trapper Dominator, Defender). */
     forceFire?: boolean;
+    /** Barrel color - by default this is set to the 'Barrel' color id. */
+    color?: Color;
     /** The definition of the bullet that is shot from the barrel. */
     bullet: BulletDefinition;
 }

--- a/src/Const/TankDefinitions.ts
+++ b/src/Const/TankDefinitions.ts
@@ -71,6 +71,8 @@ export interface BarrelDefinition {
     angle: number;
     /** The x offset of the barrel (think of Twin's barrels for example) at base radius (50).  */
     offset: number;
+    /** The y offset of the barrel (distance from the tanks main body) at base radius (50). Will have no effect on clientside tankrendering.*/
+    distance?: number;
     /** The size of the barrel. Think of Sniper, the longer side is the size.  */
     size: number;
     /** The width of the barrel. Think of Sniper, the shorter side is the width. Width is used to determine bullet size */
@@ -123,26 +125,30 @@ export interface TankDefinition {
     flags: {
         /** If the tank can go invisible. */
         invisibility: boolean;
-        /** If the tank has a Predator-like zoom ability */
+        /** If the tank has a Predator-like zoom ability. */
         zoomAbility: boolean;
-        /** If the tank can claim squares by killing them (necro) */
+        /** If the tank can claim squares by killing them (necro). */
         canClaimSquares?: boolean;
         /** If the tank requires devmode to access (unused). */
         devOnly: boolean;
+        /** If the tank should be rendered as a star (eg. traps are stars with 3 sides). */
+        displayAsStar?: boolean;
+        /** If the tank should be rendered as a trapezoid (eg. drone barrels are trapezoids), sides needs to be set to 2 for this to take effect. */
+        displayAsTrapezoid?: boolean;
     },
-    /** How much the opacity increases per tick while shooting */
+    /** How much the opacity increases per tick while shooting. */
     visibilityRateShooting: number;
-    /** How much the opacity increases per tick while moving */
+    /** How much the opacity increases per tick while moving. */
     visibilityRateMoving: number;
-    /** How much does the opacity decrease per tick */
+    /** How much does the opacity decrease per tick. */
     invisibilityRate: number;
     /** Used to determine the FOV of a tank. */
     fieldFactor: number;
-    /** The speed of the tank */
+    /** The speed of the tank. */
     speed: number;
-    /** The absorbtionFactor (field) of the tank */
+    /** The absorbtionFactor (field) of the tank. */
     absorbtionFactor: number;
-    /** The base max health of the tank */
+    /** The base max health of the tank. */
     maxHealth: number;
     /** The addon, if not empty, which is built before the barrels. */
     preAddon: addonId | null;
@@ -150,8 +156,14 @@ export interface TankDefinition {
     postAddon: addonId | null;
     /** The sides of the tank's body. */
     sides: number;
+    /** The ratio used for size to width calculation, only takes effect when sides is 2 (rectangle). */
+    widthRatio?: number;
     /** The border width of the tank's body. */
     borderWidth: number;
+    /** Can be used to override the tank's body color. */
+    colorOverride?: Color;
+    /** Can be used to override the tank body's base size. */
+    baseSizeOverride?: number;
     /** The tank's barrels. */
     barrels: BarrelDefinition[];
     /** The tank's stat names and limits. */

--- a/src/Entity/Object.ts
+++ b/src/Entity/Object.ts
@@ -287,8 +287,22 @@ export default class ObjectEntity extends Entity {
 
             if (entity.physicsData.values.sides === 0) continue;
             if (entity.physicsData.values.sides === 2 && this.physicsData.values.sides === 2) {
-                // in Diep.io source code, rectangles do not support collisions
-                // hence, they are not supported here
+                // in Diep.io source code, rectangles do not support collisions with other rectangles
+                // uncomment the following code to enable rect on rect collisions
+                /*
+                const rect1Left = this.positionData.values.x - this.physicsData.values.width / 2;
+                const rect1Right = this.positionData.values.x + this.physicsData.values.width / 2;
+                const rect1Top = this.positionData.values.y - this.physicsData.values.size / 2;
+                const rect1Bottom = this.positionData.values.y + this.physicsData.values.size / 2;
+                const rect2Left = entity.positionData.values.x - entity.physicsData.values.width / 2;
+                const rect2Right = entity.positionData.values.x + entity.physicsData.values.width / 2;
+                const rect2Top = entity.positionData.values.y - entity.physicsData.values.size / 2;
+                const rect2Bottom = entity.positionData.values.y + entity.physicsData.values.size / 2;
+                if (rect1Left <= rect2Right &&
+                        rect1Right >= rect2Left &&
+                        rect1Top <= rect2Bottom &&
+                        rect1Bottom >= rect2Top) this.cachedCollisions.push(entity);
+                */
             } else if (this.physicsData.values.sides !== 2 && entity.physicsData.values.sides === 2) {
                 const dX = util.constrain(this.positionData.values.x, entity.positionData.values.x - entity.physicsData.values.size / 2, entity.positionData.values.x + entity.physicsData.values.size / 2) - this.positionData.values.x;
                 const dY = util.constrain(this.positionData.values.y, entity.positionData.values.y - entity.physicsData.values.width / 2, entity.positionData.values.y + entity.physicsData.values.width / 2) - this.positionData.values.y;

--- a/src/Entity/Tank/Barrel.ts
+++ b/src/Entity/Tank/Barrel.ts
@@ -118,7 +118,7 @@ export default class Barrel extends ObjectEntity {
         this.definition = barrelDefinition;
 
         // Begin Loading Definition
-        this.styleData.values.color = Color.Barrel;
+        this.styleData.values.color = this.definition.color ?? Color.Barrel;
         this.physicsData.values.sides = 2;
         if (barrelDefinition.isTrapezoid) this.physicsData.values.flags |= PhysicsFlags.isTrapezoid;
 

--- a/src/Entity/Tank/Barrel.ts
+++ b/src/Entity/Tank/Barrel.ts
@@ -131,8 +131,8 @@ export default class Barrel extends ObjectEntity {
 
         this.physicsData.values.width = this.definition.width * sizeFactor;
         this.positionData.values.angle = this.definition.angle + (this.definition.trapezoidDirection);
-        this.positionData.values.x = Math.cos(this.definition.angle) * size / 2 - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
-        this.positionData.values.y = Math.sin(this.definition.angle) * size / 2 + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.values.x = Math.cos(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.values.y = Math.sin(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
 
         // addons are below barrel, use StyleFlags.aboveParent to go above parent
         if (barrelDefinition.addon) {
@@ -221,8 +221,8 @@ export default class Barrel extends ObjectEntity {
 
         this.physicsData.width = this.definition.width * sizeFactor;
         this.positionData.angle = this.definition.angle + (this.definition.trapezoidDirection);
-        this.positionData.x = Math.cos(this.definition.angle) * size / 2 - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
-        this.positionData.y = Math.sin(this.definition.angle) * size / 2 + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.x = Math.cos(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.y = Math.sin(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
 
         // Updates bullet accel too
         this.bulletAccel = (20 + (this.tank.cameraEntity.cameraData?.values.statLevels.values[Stat.BulletSpeed] || 0) * 3) * this.definition.bullet.speed;

--- a/src/Entity/Tank/Projectile/Bullet.ts
+++ b/src/Entity/Tank/Projectile/Bullet.ts
@@ -97,8 +97,8 @@ export default class Bullet extends LivingEntity {
 
         const {x, y} = tank.getWorldPosition();
         
-        this.positionData.values.x = x + (Math.cos(shootAngle) * barrel.physicsData.values.size) - Math.sin(shootAngle) * barrel.definition.offset * sizeFactor;
-        this.positionData.values.y = y + (Math.sin(shootAngle) * barrel.physicsData.values.size) + Math.cos(shootAngle) * barrel.definition.offset * sizeFactor;
+        this.positionData.values.x = x + (Math.cos(shootAngle) * barrel.physicsData.values.size) - Math.sin(shootAngle) * barrel.definition.offset * sizeFactor + Math.cos(shootAngle) * (barrel.definition.distance || 0);
+        this.positionData.values.y = y + (Math.sin(shootAngle) * barrel.physicsData.values.size) + Math.cos(shootAngle) * barrel.definition.offset * sizeFactor + Math.sin(shootAngle) * (barrel.definition.distance || 0);
         this.positionData.values.angle = shootAngle;
     }
 

--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -144,9 +144,10 @@ export default class TankBody extends LivingEntity implements BarrelBase {
 
         // Size ratios
         this.baseSize = tank.sides === 4 ? Math.SQRT2 * 32.5 : tank.sides === 16 ? Math.SQRT2 * 25 : 50;
+        if (tank.baseSizeOverride !== undefined) this.baseSize = tank.baseSizeOverride;
         this.physicsData.absorbtionFactor = this.isInvulnerable ? 0 : tank.absorbtionFactor;
         if (tank.absorbtionFactor === 0) this.positionData.flags |= PositionFlags.canMoveThroughWalls;
-        else if (this.positionData.flags & PositionFlags.canMoveThroughWalls) this.positionData.flags ^= PositionFlags.canMoveThroughWalls
+        else if (this.positionData.flags & PositionFlags.canMoveThroughWalls) this.positionData.flags ^= PositionFlags.canMoveThroughWalls;
 
         camera.cameraData.tank = this._currentTank = id;
         if (tank.upgradeMessage && camera instanceof ClientCamera) camera.client.notify(tank.upgradeMessage);
@@ -325,6 +326,16 @@ export default class TankBody extends LivingEntity implements BarrelBase {
             // Dont worry about invulnerability here - not gonna be invulnerable while flashing ever (see setInvulnerability)
             this.damageReduction = 1.0;
         }
+
+        if (this.definition.colorOverride !== undefined) this.styleData.color = this.definition.colorOverride;
+        if (this.definition.sides === 2) {
+            if (this.definition.widthRatio !== undefined) {
+                this.physicsData.width = this.physicsData.size * this.definition.widthRatio;
+            } else {
+                this.physicsData.width = this.physicsData.size;
+            }
+            if (this.definition.flags.displayAsTrapezoid === true) this.physicsData.flags |= PhysicsFlags.isTrapezoid;
+        } else if (this.definition.flags.displayAsStar === true) this.styleData.flags |= StyleFlags.isStar;
 
         this.accel.add({
             x: this.inputs.movement.x * this.cameraEntity.cameraData.values.movementSpeed,

--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -143,8 +143,7 @@ export default class TankBody extends LivingEntity implements BarrelBase {
         }
 
         // Size ratios
-        this.baseSize = tank.sides === 4 ? Math.SQRT2 * 32.5 : tank.sides === 16 ? Math.SQRT2 * 25 : 50;
-        if (tank.baseSizeOverride !== undefined) this.baseSize = tank.baseSizeOverride;
+        this.baseSize = tank.baseSizeOverride ?? tank.sides === 4 ? Math.SQRT2 * 32.5 : tank.sides === 16 ? Math.SQRT2 * 25 : 50;
         this.physicsData.absorbtionFactor = this.isInvulnerable ? 0 : tank.absorbtionFactor;
         if (tank.absorbtionFactor === 0) this.positionData.flags |= PositionFlags.canMoveThroughWalls;
         else if (this.positionData.flags & PositionFlags.canMoveThroughWalls) this.positionData.flags ^= PositionFlags.canMoveThroughWalls;
@@ -246,7 +245,6 @@ export default class TankBody extends LivingEntity implements BarrelBase {
     }
 
     public tick(tick: number) {
-
         this.positionData.angle = Math.atan2(this.inputs.mouse.y - this.positionData.values.y, this.inputs.mouse.x - this.positionData.values.x);
 
         if (this.isInvulnerable) {
@@ -329,11 +327,7 @@ export default class TankBody extends LivingEntity implements BarrelBase {
 
         if (this.definition.colorOverride !== undefined) this.styleData.color = this.definition.colorOverride;
         if (this.definition.sides === 2) {
-            if (this.definition.widthRatio !== undefined) {
-                this.physicsData.width = this.physicsData.size * this.definition.widthRatio;
-            } else {
-                this.physicsData.width = this.physicsData.size;
-            }
+            this.physicsData.width = this.physicsData.size * (this.definition.widthRatio ?? 1);
             if (this.definition.flags.displayAsTrapezoid === true) this.physicsData.flags |= PhysicsFlags.isTrapezoid;
         } else if (this.definition.flags.displayAsStar === true) this.styleData.flags |= StyleFlags.isStar;
 

--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -73,6 +73,8 @@ export default class TankBody extends LivingEntity implements BarrelBase {
     public reloadTime = 15;
     /** The current tank definition / tank id. */
     private _currentTank: Tank | DevTank = Tank.Basic;
+    /** Caches the tanks color for future use. */
+    private _currentColor: Color = Color.Tank;
     /** Sets tanks to be invulnerable - example, godmode, or AC */
     public isInvulnerable: boolean = false;
 
@@ -147,6 +149,15 @@ export default class TankBody extends LivingEntity implements BarrelBase {
         this.physicsData.absorbtionFactor = this.isInvulnerable ? 0 : tank.absorbtionFactor;
         if (tank.absorbtionFactor === 0) this.positionData.flags |= PositionFlags.canMoveThroughWalls;
         else if (this.positionData.flags & PositionFlags.canMoveThroughWalls) this.positionData.flags ^= PositionFlags.canMoveThroughWalls;
+
+        if (this.definition.colorOverride !== undefined) {
+            if (this.styleData.values.color !== this.definition.colorOverride) {
+                this._currentColor = this.styleData.values.color;
+                this.styleData.color = this.definition.colorOverride;
+            }
+        } else if (this.styleData.values.color !== this._currentColor) {
+            this.styleData.color = this._currentColor;
+        }
 
         camera.cameraData.tank = this._currentTank = id;
         if (tank.upgradeMessage && camera instanceof ClientCamera) camera.client.notify(tank.upgradeMessage);
@@ -325,7 +336,6 @@ export default class TankBody extends LivingEntity implements BarrelBase {
             this.damageReduction = 1.0;
         }
 
-        if (this.definition.colorOverride !== undefined) this.styleData.color = this.definition.colorOverride;
         if (this.definition.sides === 2) {
             this.physicsData.width = this.physicsData.size * (this.definition.widthRatio ?? 1);
             if (this.definition.flags.displayAsTrapezoid === true) this.physicsData.flags |= PhysicsFlags.isTrapezoid;


### PR DESCRIPTION
### Why:
Fun?

### Summarize what's being changed (include any screenshots, code, or other media if available):
added fields (and logic):
- barrel/distance (y-offset aka distance of barrel from body)
- barrel/color (color override)
- tank/flags/displayAsStar
- tank/flags/displayAsTrapezoid
- tank/widthRatio (if the body is a rect, this can be used to modify the ratio of size to width)
- tank/colorOverride (color override; rules: only applied on setTank, stores cached color)
- tank/baseSizeOverride

### Confirm the following:
- [x] I have tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

