### PR TITLE
inaccurate pred fov

### DIFF
--- a/src/Entity/Tank/TankBody.ts
+++ b/src/Entity/Tank/TankBody.ts
@@ -283,8 +283,8 @@ export default class TankBody extends LivingEntity implements BarrelBase {
         if (this.definition.flags.zoomAbility && (this.inputs.flags & InputFlags.rightclick)) {
             if (!(this.cameraEntity.cameraData.values.flags & CameraFlags.usesCameraCoords)) {
                 const angle = Math.atan2(this.inputs.mouse.y - this.positionData.values.y, this.inputs.mouse.x - this.positionData.values.x)
-                this.cameraEntity.cameraData.cameraX = Math.cos(angle) * 1000 + this.positionData.values.x;
-                this.cameraEntity.cameraData.cameraY = Math.sin(angle) * 1000 + this.positionData.values.y;
+                this.cameraEntity.cameraData.cameraX = Math.cos(angle) * 1500 + this.positionData.values.x;
+                this.cameraEntity.cameraData.cameraY = Math.sin(angle) * 1500 + this.positionData.values.y;
                 this.cameraEntity.cameraData.flags |= CameraFlags.usesCameraCoords;
             }
         } else if (this.cameraEntity.cameraData.values.flags & CameraFlags.usesCameraCoords) this.cameraEntity.cameraData.flags ^= CameraFlags.usesCameraCoords;


### PR DESCRIPTION
abc asked 4 it
tankbody 286 and 287 had a 1000 multiplier in them which is inaccurate instead it must be 1500 to fix pred fov when zooming

please make sure all tanks are not impacted before accepting this pr and thank you :3