### PR TITLE
Fix tank barrel distance not scaling with tank

### DIFF
--- a/src/Entity/Tank/Barrel.ts
+++ b/src/Entity/Tank/Barrel.ts
@@ -131,8 +131,8 @@ export default class Barrel extends ObjectEntity {
 
         this.physicsData.values.width = this.definition.width * sizeFactor;
         this.positionData.values.angle = this.definition.angle + (this.definition.trapezoidDirection);
-        this.positionData.values.x = Math.cos(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
-        this.positionData.values.y = Math.sin(this.definition.angle) * (size / 2 + (this.definition.distance || 0)) + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.values.x = Math.cos(this.definition.angle) * (size / 2 + ((this.definition.distance ?? 0) * sizeFactor)) - Math.sin(this.definition.angle) * this.definition.offset * sizeFactor;
+        this.positionData.values.y = Math.sin(this.definition.angle) * (size / 2 + ((this.definition.distance ?? 0) * sizeFactor)) + Math.cos(this.definition.angle) * this.definition.offset * sizeFactor;
 
         // addons are below barrel, use StyleFlags.aboveParent to go above parent
         if (barrelDefinition.addon) {


### PR DESCRIPTION
<!--
Thank you for helping out with diepcustom! Please submit the form below so that we can process this request properly
-->
### Why:
<!-- If there's an existing issue for your change, please link to it in the brackets above.
 If there is not an existing issue, and this is patching a bug or inconsistency, please consider making an issue. -->
Previously, the `distance` property for barrels in tank definitions did not scale with the tank when leveling up. This has been resolved by this PR. This has been tested on my own server and works fine.

### Summarize what's being changed (include any screenshots, code, or other media if available):
<!-- Let us know what you are changing. Share anything that could provide the most context. -->
Previous behavior:
https://github.com/user-attachments/assets/47b254c7-a8f0-43d9-a185-61e6ba04b2c6

Fixed behavior:
https://github.com/user-attachments/assets/29b2a5db-d3d4-47e8-8bd4-2fe83bf8d458

### Confirm the following:
- [X] I have tested these changes (by compiling, running, and playing) and have seen no unintended differences in gameplay

